### PR TITLE
added logic for when numerator is deleted we add placeholder atom

### DIFF
--- a/src/core-definitions/functions.ts
+++ b/src/core-definitions/functions.ts
@@ -183,9 +183,11 @@ defineFunction(
           break;
         default:
       }
+      let numerEmpty = false;
+      if (args[0]) numerEmpty = args[0]['group'].length === 0;
 
       return new GenfracAtom(
-        !args[0] ? [new PlaceholderAtom()] : argAtoms(args[0]),
+        numerEmpty ? [new PlaceholderAtom()] : argAtoms(args[0]),
         !args[1] ? [new PlaceholderAtom()] : argAtoms(args[1]),
         genfracOptions
       );


### PR DESCRIPTION
Our goal is to modify this existing library such that when we create a fraction (Pic 1), then insert a numerator, then delete that numerator, we'd like a placeholder to be rendered. 
<img width="795" alt="image" src="https://github.com/concord-consortium/mathlive/assets/521934/736f070a-ae2e-4763-a24b-8c9d7b7a876d">



