### PR TITLE
add a character to make empty groups visible

### DIFF
--- a/src/core/atom-class.ts
+++ b/src/core/atom-class.ts
@@ -1159,10 +1159,20 @@ export class Atom<T extends (Argument | null)[] = (Argument | null)[]> {
     context: Context,
     options?: { classes?: string; boxType?: BoxType }
   ): Box {
-    const value = this.value ?? this.body;
+    let value = this.value ?? this.body;
+    let overriddenBoxType;
+
+    if (this.type === 'first') {
+      const { parent, parentBranch } = this;
+      if (parentBranch && parent?.branch(parentBranch)?.length === 1) {
+        // we are a first atom in an "empty group"
+        value = '⊙';
+        overriddenBoxType = 'ord';
+      }
+    }
 
     // Get the right BoxType for this atom type
-    const type = options?.boxType ?? boxType(this.type);
+    const type = overriddenBoxType ?? options?.boxType ?? boxType(this.type);
 
     // The font family is determined by:
     // - the base font family associated with this atom (optional). For example,


### PR DESCRIPTION
This is currently just a demo to see if I can show a character when there is an empty group.

The createBox method seemed the best place I could find to put this. 
It is also possible to identify them in the `Box.toMarkup` method, but it seems identifying them here is better. 

I think we we'll want is to use the placeholder character instead of the bullseye I'm using here. And we'll also want to figure out how to get the cursor working more like the placeholder, so the empty group becomes selected instead of showing a cursor next to it.

We also want to figure out how to show placeholders on either side of binary operators like `+`, `-`, `*` if there isn't something valid next to them. That seems like it is going to be a completely different feature though which will require using the evaluation of the expression to then influence the display of the expression. 
